### PR TITLE
Response.headers is a non-iterable object and can't be spread in some instances

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -164,7 +164,7 @@ class Cache {
     let folder = wm(this)
     let cache = {
       cacheName: folder,
-      headers: [...res.headers],
+      headers: [...res.headers.entries()],
       status: res.status,
       statusText: res.statusText,
       body: await res.arrayBuffer(),


### PR DESCRIPTION
I've not been able to figure out exactly why this happens in some instances and not others, but in a project that I use cache-polyfill, in my production, minified package, the call to "put" started failing recently with this error:

> TypeError: Invalid attempt to spread non-iterable instance. In order to be iterable, non-array objects must have a [Symbol.iterator]() method.

Which occurred at the point you spread the Response.headers:

`headers: [...res.headers]}`

Technically, that shouldn't be allowed and the error I'm getting makes sense. [Response.headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers) is an object, and thus non-iterable. But apparently it's been working for you and it has worked for me up until the last few days, and continues to work in my development package (non-minified, but otherwise the same transpiling). 

So, that's as much info as I have as to what is happening. Making the change in this pull request fixes the issue for me in my production package,. All it does is change the spread from the headers to the [headers.entries](https://developer.mozilla.org/en-US/docs/Web/API/Headers/entries) which simply gets an iterator for the headers object and spreads successfully. It shouldn't have any negative effects. I'll be using my fork in my project, but would rather use the official NPM package, so please considering merging. Thanks.